### PR TITLE
2.0.0-0.1.3: [FIX] - Set Base Locale

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote",
-  "version": "2.0.0-0.1.2",
+  "version": "2.0.0-0.1.3",
   "scripts": {
     "dev": "vite dev",
     "dev-https": "vite dev --mode https",

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -19,7 +19,9 @@ export const load: LayoutLoad = async ({ url }) => {
   /** LOAD TRANSLATIONS */
   const defaultLocale = 'en'
   const initLocale = settings$.value.language || locale.get() || defaultLocale
-  await loadTranslations(initLocale)
+  const baseLocale = initLocale.split('-')[0]
+
+  await loadTranslations(baseLocale)
 
   if (browser) {
     await db.open()


### PR DESCRIPTION
Sets the base local so that we render the translations for all variants of a base locale. For example for `en-US`, `en-UK` and `en-AU` we will just render the `en` translations for all of them.