### PR TITLE
2.0.0-0.1.4: [FIX] - Editable Heading

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote",
-  "version": "2.0.0-0.1.2",
+  "version": "2.0.0-0.1.4",
   "scripts": {
     "dev": "vite dev",
     "dev-https": "vite dev --mode https",

--- a/src/lib/components/SectionHeading.svelte
+++ b/src/lib/components/SectionHeading.svelte
@@ -8,7 +8,7 @@
   export let icon = ''
   export let editable = false
 
-  $: if (!text) {
+  $: if (!text && !editable) {
     text = $translate(`app.routes.${$page.url.pathname}.title`)
   }
 


### PR DESCRIPTION
Fixes a bug when editing the wallet name, if you cleared it completely it would try and replace it with the route title.