### PR TITLE
2.0.0-0.1.7: [FIX] - Delete Replaced Onchain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote",
-  "version": "2.0.0-0.1.6",
+  "version": "2.0.0-0.1.7",
   "scripts": {
     "dev": "vite dev",
     "dev-https": "vite dev --mode https",

--- a/src/lib/db/db.worker.ts
+++ b/src/lib/db/db.worker.ts
@@ -102,11 +102,17 @@ onmessage = async (message: MessageEvent<Message>) => {
 
         if (transactions.length) {
           await Promise.all(
-            transactions.map(transaction =>
-              db.payments.update(transaction.id, transaction).then(updated => {
+            transactions.map(async transaction => {
+              // CLN replaced(?) transaction has a block height of 0
+              if (transaction.data.blockHeight === 0) {
+                await db.payments.delete(transaction.id)
+                return
+              }
+
+              return db.payments.update(transaction.id, transaction).then(updated => {
                 !updated && db.payments.put(transaction)
               })
-            )
+            })
           )
         }
 


### PR DESCRIPTION
Deletes onchain transactions from the local db if the `blockHeight === 0` which seems to be Core Lightning's way of saying the transaction was replaced.