### PR TITLE
2.1.1-0.0.1 - Enhancement: Tweak Input/Scan copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote",
-  "version": "2.1.1",
+  "version": "2.1.1-0.0.1",
   "scripts": {
     "dev": "vite dev",
     "dev-https": "vite dev --mode https",

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -149,6 +149,7 @@
     "expires": "Expires",
     "text": "Text",
     "image": "Image",
+    "import": "Import",
     "nfc": "NFC",
     "unknown": "Unknown",
     "login": "Login",

--- a/src/lib/i18n/es.json
+++ b/src/lib/i18n/es.json
@@ -149,6 +149,7 @@
     "expires": "Expira",
     "text": "Texto",
     "image": "Imagen",
+    "import": "Importar",
     "nfc": "NFC",
     "unknown": "Desconocido",
     "login": "Acceso",

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -238,7 +238,7 @@
 
         <a href="/input" class="flex flex-col items-center justify-center no-underline">
           <div class="w-8">{@html scan}</div>
-          <span class="text-xs font-semibold">{$translate('app.labels.input')}</span>
+          <span class="text-xs font-semibold">{$translate('app.labels.scan')}</span>
         </a>
 
         <a href="/payments/receive" class="flex flex-col items-center justify-center no-underline">

--- a/src/routes/input/+page.svelte
+++ b/src/routes/input/+page.svelte
@@ -13,7 +13,7 @@
   import { isBolt12Offer, parseInput } from '$lib/input-parser.js'
   import type { PageData } from './$types.js'
 
-  type InputKey = 'scan' | 'text' | 'image' | 'nfc'
+  type InputKey = 'scan' | 'paste' | 'import' | 'nfc'
 
   export let data: PageData
 
@@ -21,8 +21,8 @@
 
   const inputs: InputKey[] = [
     'scan',
-    'text',
-    'image',
+    'paste',
+    'import',
     ...(nfc.available() ? ['nfc' as InputKey] : [])
   ]
 
@@ -107,9 +107,9 @@
         <div class="w-full flex items-center">
           <Scan on:input={e => handleInput(e.detail)} />
         </div>
-      {:else if input === 'text'}
+      {:else if input === 'paste'}
         <Text on:input={e => handleInput(e.detail)} />
-      {:else if input === 'image'}
+      {:else if input === 'import'}
         <Image on:input={e => handleInput(e.detail)} />
       {:else if input === 'nfc'}
         <NFCComponent on:input={e => handleInput(e.detail)} />


### PR DESCRIPTION
After reviewing feedback from the recent design session in Austin and gathering insights from LNPlay events, it's evident that users find the 'Input' label confusing. I propose renaming 'Input' to 'Scan' in the header of the app.: 

<img width="1048" alt="Screenshot 2024-05-06 at 8 03 01 AM" src="https://github.com/clams-tech/Remote/assets/30157175/67349297-265d-4047-a4ec-ff360168b360">

I also think it makes sense to tweak the copy of the input tabs to `Paste` and `Import`, so that they align more with `Scan`, i.e. an action that you can perform on the /input route:

<img width="1037" alt="Screenshot 2024-05-06 at 8 03 28 AM" src="https://github.com/clams-tech/Remote/assets/30157175/39a0365e-9fbd-4011-9edd-11d76d858541">

What do you think @aaronbarnardsound?