### PR TITLE
2.1.1-0.2.4: [ENH] - Channels Spendable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote",
-  "version": "2.1.1-0.1.4",
+  "version": "2.1.1-0.2.4",
   "scripts": {
     "dev": "vite dev",
     "dev-https": "vite dev --mode https",

--- a/src/lib/@types/channels.ts
+++ b/src/lib/@types/channels.ts
@@ -102,7 +102,7 @@ export type OpenChannelOptions = {
   /** node public key to open channel to */
   id: string
   /** amount in sats for channel size */
-  amount: number
+  amount: number | 'all'
   /** whether to announce the channel to the network or not */
   announce: boolean
 }

--- a/src/lib/components/Msg.svelte
+++ b/src/lib/components/Msg.svelte
@@ -59,7 +59,7 @@
     <div
       in:slide={{ duration: 250 }}
       out:slide={{ duration: 250, delay: 150 }}
-      class="pl-6 pr-8 w-full py-4 rounded-lg border flex relative overflow-hidden transition-all {msgValue
+      class="pl-6 pr-8 w-full py-4 rounded-lg border flex flex-col relative overflow-hidden transition-all {msgValue
         .colors.main}"
     >
       {#if closable}
@@ -78,9 +78,11 @@
           </div>
         </div>
 
-        <div class="font-semibold text-sm leading-tight flex items-center flex-wrap gap-x-1">
+        <div class="font-semibold text-sm leading-tight flex items-center flex-wrap gap-x-0.5">
           <!-- text-bitcoin-orange -->
           {@html message}
+
+          <slot name="inline" />
         </div>
       </div>
 

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -163,7 +163,7 @@
     "channel": "Channel",
     "closed_by": "Closed by",
     "final_to_us": "Our final balance",
-    "announce_channel": "Announce channel?",
+    "announce_channel": "Announce channel",
     "opened_by": "Opened by",
     "ppm": "PPM",
     "channel_fees": "Set Fees",
@@ -508,7 +508,8 @@
     "close_channel": "Close Channel",
     "seconds": "seconds",
     "force_close": "Force close",
-    "go_to_closing_transaction": "Go to closing transaction"
+    "go_to_closing_transaction": "Go to closing transaction",
+    "spend_all": "Spend all"
   },
   "messages": {
     "closing_channel": "Closing a channel will publish an onchain transaction and settle the current channel balances.",

--- a/src/lib/i18n/es.json
+++ b/src/lib/i18n/es.json
@@ -507,7 +507,8 @@
     "close_channel": "Cerrar canal",
     "seconds": "segundos",
     "force_close": "Forzar cierre",
-    "go_to_closing_transaction": "Ir a la transacción de cierre"
+    "go_to_closing_transaction": "Ir a la transacción de cierre",
+    "spend_all": "Gastar todo"
   },
   "messages": {
     "closing_channel": "Cerrar un canal publicará una transacción en la cadena y liquidará los saldos actuales del canal.",

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -64,6 +64,7 @@
         type="info"
       >
         <button
+          slot="inline"
           class="ml-1 underline font-semibold text-sm leading-tight"
           on:click={async () => {
             const { id } = await createWallet()

--- a/src/routes/channels/open/+page.svelte
+++ b/src/routes/channels/open/+page.svelte
@@ -11,7 +11,7 @@
   import SectionHeading from '$lib/components/SectionHeading.svelte'
   import Msg from '$lib/components/Msg.svelte'
   import plus from '$lib/icons/plus.js'
-  import { combineLatest, from, map } from 'rxjs'
+  import { combineLatest, map } from 'rxjs'
   import { connections$, wallets$ } from '$lib/streams.js'
   import WalletSelector from '$lib/components/WalletSelector.svelte'
   import type { Connection } from '$lib/wallets/interfaces.js'


### PR DESCRIPTION
This PR makes some small additions to the open channel UI:

- Displays spendable balance so you can know how much can be used to fund a channel
- Adds a spend all toggle so that the max remaining balance can be used to fund a channel
- Reverts style change in the `Msg` component from #253 as it broke the error message rendering. I opted for adding a new slot in the component to be able to render content inline

<img width="854" alt="Screenshot 2024-05-26 at 4 38 53 PM" src="https://github.com/clams-tech/Remote/assets/29873495/f823f38b-77b0-41bb-8e57-73def1bef6c8">
<img width="855" alt="Screenshot 2024-05-26 at 4 39 01 PM" src="https://github.com/clams-tech/Remote/assets/29873495/3bf31a0e-3e3a-4b82-bbc4-a3b2368e01a7">
