### PR TITLE
[2.1.1-0.1.5]: Fix - payment row cutoff on small screens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote",
-  "version": "2.1.1-0.1.4",
+  "version": "2.1.1-0.1.5",
   "scripts": {
     "dev": "vite dev",
     "dev-https": "vite dev --mode https",

--- a/src/routes/payments/PaymentRow.svelte
+++ b/src/routes/payments/PaymentRow.svelte
@@ -40,7 +40,7 @@
 </script>
 
 <a
-  class="flex items-center justify-between py-3 w-full overflow-hidden hover:bg-neutral-800/80 transition-colors no-underline px-2 bg-neutral-900 text-sm xs:text-base h-[5.5rem]"
+  class="flex items-center justify-between py-3 w-full overflow-hidden hover:bg-neutral-800/80 transition-colors no-underline px-2 bg-neutral-900 text-sm xs:text-base h-[7rem]"
   href={`/payments/${id}?wallet=${walletId}`}
 >
   <div class="flex items-start h-full flex-1 overflow-hidden">


### PR DESCRIPTION
See the first payment, bottom of the list on the before image.

Before: 
![image](https://github.com/clams-tech/Remote/assets/30157175/5b4feec5-c238-4535-a78f-21950b8d83f0)

After: 
![image](https://github.com/clams-tech/Remote/assets/30157175/3686d054-09fe-48f8-922e-99d00e1886fb)
