### PR TITLE
2.1.1-0.2.6: Enhancement: Improve the Tor connection experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote",
-  "version": "2.1.1-0.1.4",
+  "version": "2.1.1-0.1.6",
   "scripts": {
     "dev": "vite dev",
     "dev-https": "vite dev --mode https",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote",
-  "version": "2.1.1-0.1.6",
+  "version": "2.1.1-0.2.6",
   "scripts": {
     "dev": "vite dev",
     "dev-https": "vite dev --mode https",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -14,6 +14,7 @@ export const MODE = import.meta.env.MODE
 export const API_HOST = 'api.clams.tech'
 export const API_URL = `https://${API_HOST}`
 export const WS_PROXY = `wss://${API_HOST}/ws-proxy`
+export const ALBY_WS_PROXY = 'wss://lnproxy.getalby.com'
 
 export const SEC_IN_MS = 1000
 export const MIN_IN_MS = 60 * 1000

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -508,7 +508,8 @@
     "close_channel": "Close Channel",
     "seconds": "seconds",
     "force_close": "Force close",
-    "go_to_closing_transaction": "Go to closing transaction"
+    "go_to_closing_transaction": "Go to closing transaction",
+    "tor_support": "Tor support"
   },
   "messages": {
     "closing_channel": "Closing a channel will publish an onchain transaction and settle the current channel balances.",

--- a/src/lib/i18n/es.json
+++ b/src/lib/i18n/es.json
@@ -507,7 +507,8 @@
     "close_channel": "Cerrar canal",
     "seconds": "segundos",
     "force_close": "Forzar cierre",
-    "go_to_closing_transaction": "Ir a la transacción de cierre"
+    "go_to_closing_transaction": "Ir a la transacción de cierre",
+    "tor_support": "Soporte de Tor"
   },
   "messages": {
     "closing_channel": "Cerrar un canal publicará una transacción en la cadena y liquidará los saldos actuales del canal.",

--- a/src/lib/wallets/configurations/coreln/AdvancedConnection.svelte
+++ b/src/lib/wallets/configurations/coreln/AdvancedConnection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { fade } from 'svelte/transition'
-  import { WS_PROXY } from '$lib/constants'
+  import { ALBY_WS_PROXY, WS_PROXY } from '$lib/constants'
   import TextInput from '$lib/components/TextInput.svelte'
   import { translate } from '$lib/i18n/translations'
   import type { CoreLnConfiguration } from '$lib/@types/wallets.js'
@@ -136,7 +136,19 @@
     </div>
   {:else}
     <div in:fade={{ duration: 250 }} class="mt-2 w-full">
-      <TextInput micro value={WS_PROXY} name={advancedConnectOption} readonly />
+      <div
+        class="flex items-center px-3 py-2 ring-2 ring-purple-500 border border-neutral-600 rounded"
+      >
+        <label class="flex items-center cursor-pointer">
+          <input type="radio" bind:group={connection.value} value={WS_PROXY} />
+          <span class="ml-1">Clams</span>
+        </label>
+
+        <label class="flex items-center ml-4 cursor-pointer">
+          <input type="radio" bind:group={connection.value} value={ALBY_WS_PROXY} />
+          <span class="ml-1">Alby ({$translate('app.labels.tor_support')})</span>
+        </label>
+      </div>
     </div>
   {/if}
 </div>

--- a/src/lib/wallets/index.ts
+++ b/src/lib/wallets/index.ts
@@ -153,6 +153,8 @@ export const getConnection = (wallet: Wallet): Connection => {
 }
 
 export const connect = async (wallet: Wallet): Promise<Connection> => {
+  console.log('wallet = ', wallet)
+
   let connection: Connection
 
   // lookup if connection exists

--- a/src/lib/wallets/index.ts
+++ b/src/lib/wallets/index.ts
@@ -153,8 +153,6 @@ export const getConnection = (wallet: Wallet): Connection => {
 }
 
 export const connect = async (wallet: Wallet): Promise<Connection> => {
-  console.log('wallet = ', wallet)
-
   let connection: Connection
 
   // lookup if connection exists


### PR DESCRIPTION
- Change out the `App Proxy` input field for a couple of radio options- `Clams` and `Alby (Tor support)`.
- When user selects Alby, we use the alby websocket proxy allowing Tor nodes to connect without having to use the Custom proxy input field.
- I opted for radios to match the styling of the `Direct Connection` tab.
- I tested connecting a Tor node and a clearnet node, no issues found.

<img width="374" alt="Screenshot 2024-05-26 at 12 53 16 PM" src="https://github.com/clams-tech/Remote/assets/30157175/955bd782-2c97-4473-9f73-ba071ac51049">
