### PR TITLE
2.1.1-0.3.7: [Enhancement] - Increase size of input option buttons on /input screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote",
-  "version": "2.1.1-0.3.6",
+  "version": "2.1.1-0.3.7",
   "scripts": {
     "dev": "vite dev",
     "dev-https": "vite dev --mode https",

--- a/src/routes/input/+page.svelte
+++ b/src/routes/input/+page.svelte
@@ -86,12 +86,12 @@
 
   <div class="mt-4">
     <div
-      class="flex items-center text-xs font-semibold rounded-t-lg border-t-2 border-x-2 border-neutral-400 overflow-hidden w-min"
+      class="flex items-center text-xs font-semibold rounded-t-lg border-t-2 border-x-2 border-neutral-400 overflow-hidden"
     >
       {#each inputs as key}
         <button
           on:click={() => (input = key)}
-          class="px-3 py-1 block"
+          class="p-3 w-full text-center"
           class:text-neutral-900={input === key}
           class:bg-neutral-50={input === key}
         >
@@ -101,7 +101,7 @@
     </div>
 
     <div
-      class="border-2 bg-neutral-900 border-neutral-400 rounded-b-lg rounded-tr-lg shadow-md w-full overflow-hidden"
+      class="border-2 bg-neutral-900 border-neutral-400 rounded-b-lg shadow-md w-full overflow-hidden"
     >
       {#if input === 'scan'}
         <div class="w-full flex items-center">


### PR DESCRIPTION
Per Austin design club feedback: 
- Increase the size of the buttons and make them full width on the /input route to make them easier to select

Before / After on safari iphone SE: 

<img width="375" alt="signal-2024-05-29-085759" src="https://github.com/clams-tech/Remote/assets/30157175/8ad45eaa-3259-4c0b-a660-79b84f74d518">

<img width="375" alt="signal-2024-05-29-085406" src="https://github.com/clams-tech/Remote/assets/30157175/b7682787-14b7-49cd-8755-8195da33f42b">

Desktop: 

<img width="1368" alt="Screenshot 2024-05-29 at 6 01 35 PM" src="https://github.com/clams-tech/Remote/assets/30157175/31eb8baa-e9eb-41e0-a2f7-b7ac1d5e55f3">

