### PR TITLE
2.1.1-0.4.7: [Feat] - Add warnings for bitcoind and lightningd sync status

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote",
-  "version": "2.1.1-0.3.7",
+  "version": "2.1.1-0.4.7",
   "scripts": {
     "dev": "vite dev",
     "dev-https": "vite dev --mode https",

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -594,7 +594,9 @@
     "wallet_channel_open_unavailable": "You do not have any wallets connected that can open an channel.",
     "fetched_invoice_invalid": "An invalid invoice was returned when trying to pay offer.",
     "fetched_invoice_amount_invalid": "The invoice returned has a different amount than what was requested from the offer.",
-    "decode_rune": "Invalid rune."
+    "decode_rune": "Invalid rune.",
+    "bitcoind_not_synced": "Bitcoind is not fully synced.",
+    "lightningd_not_synced": "Lightningd is not fully synced."
   },
   "languages": {
     "en": "English",

--- a/src/lib/i18n/es.json
+++ b/src/lib/i18n/es.json
@@ -593,7 +593,9 @@
     "wallet_channel_open_unavailable": "No tienes ninguna billetera conectada que pueda abrir un canal.",
     "fetched_invoice_invalid": "Una factura inválida fue devuelta al intentar pagar la oferta.",
     "fetched_invoice_amount_invalid": "La factura devuelta tiene una cantidad diferente a lo requerido por la oferta.",
-    "decode_rune": "Runa inválida."
+    "decode_rune": "Runa inválida.",
+    "bitcoind_not_synced": "Bitcoind no está completamente sincronizado.",
+    "lightningd_not_synced": "Lightningd no está completamente sincronizado."
   },
   "languages": {
     "en": "Inglés",

--- a/src/lib/wallets/coreln/index.ts
+++ b/src/lib/wallets/coreln/index.ts
@@ -117,10 +117,29 @@ class CoreLightning implements CorelnConnectionInterface {
             method: 'getinfo'
           })) as GetinfoResponse
 
-          const { id, alias, color, version, address, network } = result
+          const {
+            id,
+            alias,
+            color,
+            version,
+            address,
+            network,
+            warning_bitcoind_sync,
+            warning_lightningd_sync
+          } = result
           const { address: host, port: connectionPort } = address[0] || { address: ip, port }
 
-          this.info = { id, host, port: connectionPort, alias, color, version, network }
+          this.info = {
+            id,
+            host,
+            port: connectionPort,
+            alias,
+            color,
+            version,
+            network,
+            bitcoindSynced: warning_bitcoind_sync ? false : true,
+            lightningdSynced: warning_lightningd_sync ? false : true
+          }
 
           return this.info
         } catch (error) {

--- a/src/lib/wallets/interfaces.ts
+++ b/src/lib/wallets/interfaces.ts
@@ -73,7 +73,7 @@ export type Info = {
   host?: string
   port?: number
   bitcoindSynced?: boolean
-  lightningdSynced: boolean
+  lightningdSynced?: boolean
 }
 
 export type RpcCall = (options: {

--- a/src/lib/wallets/interfaces.ts
+++ b/src/lib/wallets/interfaces.ts
@@ -72,6 +72,8 @@ export type Info = {
   version?: string
   host?: string
   port?: number
+  bitcoindSynced?: boolean
+  lightningdSynced: boolean
 }
 
 export type RpcCall = (options: {

--- a/src/routes/wallets/[id]/+page.svelte
+++ b/src/routes/wallets/[id]/+page.svelte
@@ -72,14 +72,6 @@
 
   $: connection = $connections$.find(conn => conn.walletId === id)
 
-  $: console.log(
-    `connection = 
-  
-  
-  `,
-    connection?.info
-  )
-
   $: status = connection ? connection.connectionStatus$ : new BehaviorSubject(null)
 
   $: if ($wallet$ && !$wallet$.modifiedAt) {
@@ -251,84 +243,84 @@
             </div>
           {/if}
 
-          <!-- {#if $status === 'connected'} -->
-          <div>
-            <div class="flex flex-wrap gap-1" in:fade={{ duration: 250 }}>
-              <div class="flex flex-col items-center">
-                <div class="relative w-min text-sm">
-                  <Button
-                    disabled={$wallet$ && $wallet$.syncing}
-                    on:click={sync}
-                    primary
-                    text={$translate('app.labels.sync')}
-                  >
-                    <div
-                      class:animate-spin={$wallet$ && $wallet$.syncing}
-                      class="w-4 mr-2 -ml-1"
-                      slot="iconLeft"
+          {#if $status === 'connected'}
+            <div>
+              <div class="flex flex-wrap gap-1" in:fade={{ duration: 250 }}>
+                <div class="flex flex-col items-center">
+                  <div class="relative w-min text-sm">
+                    <Button
+                      disabled={$wallet$ && $wallet$.syncing}
+                      on:click={sync}
+                      primary
+                      text={$translate('app.labels.sync')}
                     >
-                      {@html refresh}
-                    </div>
-                  </Button>
-
-                  {#if syncProgress$}
-                    <div class="absolute top-0 left-0 p-1 w-full h-full overflow-hidden">
-                      <div class="w-full h-full rounded-full overflow-hidden relative">
-                        <div
-                          transition:slide={{ duration: 250 }}
-                          style="width: {$syncProgress$}%;"
-                          class="absolute bottom-0 left-0 h-1.5 transition-all overflow-hidden bg-purple-300"
-                        />
+                      <div
+                        class:animate-spin={$wallet$ && $wallet$.syncing}
+                        class="w-4 mr-2 -ml-1"
+                        slot="iconLeft"
+                      >
+                        {@html refresh}
                       </div>
-                    </div>
-                  {/if}
+                    </Button>
+
+                    {#if syncProgress$}
+                      <div class="absolute top-0 left-0 p-1 w-full h-full overflow-hidden">
+                        <div class="w-full h-full rounded-full overflow-hidden relative">
+                          <div
+                            transition:slide={{ duration: 250 }}
+                            style="width: {$syncProgress$}%;"
+                            class="absolute bottom-0 left-0 h-1.5 transition-all overflow-hidden bg-purple-300"
+                          />
+                        </div>
+                      </div>
+                    {/if}
+                  </div>
+                </div>
+
+                <div class="w-min text-sm">
+                  <Button
+                    on:click={() => (showInfoModal = true)}
+                    text={$translate('app.labels.info')}
+                  >
+                    <div slot="iconLeft" class="w-5 mr-1 -ml-2">{@html qr}</div>
+                  </Button>
                 </div>
               </div>
 
-              <div class="w-min text-sm">
-                <Button
-                  on:click={() => (showInfoModal = true)}
-                  text={$translate('app.labels.info')}
-                >
-                  <div slot="iconLeft" class="w-5 mr-1 -ml-2">{@html qr}</div>
-                </Button>
+              <div class="w-full flex flex-col items-start mt-1.5 ml-2">
+                {#if typeof walletBalance === 'number'}
+                  <div>
+                    <BitcoinAmount sats={walletBalance} />
+                    <div class="text-xs font-semibold">
+                      {$translate('app.labels.balance')}
+                    </div>
+                  </div>
+                {/if}
               </div>
-            </div>
 
-            <div class="w-full flex flex-col items-start mt-1.5 ml-2">
-              {#if typeof walletBalance === 'number'}
-                <div>
-                  <BitcoinAmount sats={walletBalance} />
-                  <div class="text-xs font-semibold">
-                    {$translate('app.labels.balance')}
+              {#if !connection?.info?.bitcoindSynced}
+                <div class="w-full flex items-end mt-1.5 ml-2">
+                  <div class="w-4 text-utility-error mr-1">
+                    {@html warning}
+                  </div>
+                  <div class="text-utility-error text-xs font-semibold">
+                    {$translate('app.errors.bitcoind_not_synced')}
+                  </div>
+                </div>
+              {/if}
+
+              {#if !connection?.info?.lightningdSynced}
+                <div class="w-full flex items-end mt-1.5 ml-2">
+                  <div class="w-4 text-utility-error mr-1">
+                    {@html warning}
+                  </div>
+                  <div class="text-utility-error text-xs font-semibold">
+                    {$translate('app.errors.lightningd_not_synced')}
                   </div>
                 </div>
               {/if}
             </div>
-
-            {#if !connection?.info?.bitcoindSynced}
-              <div class="w-full flex items-end mt-1.5 ml-2">
-                <div class="w-4 text-utility-error mr-1">
-                  {@html warning}
-                </div>
-                <div class="text-utility-error text-xs font-semibold">
-                  {$translate('app.errors.bitcoind_not_synced')}
-                </div>
-              </div>
-            {/if}
-
-            {#if !connection?.info?.lightningdSynced}
-              <div class="w-full flex items-end mt-1.5 ml-2">
-                <div class="w-4 text-utility-error mr-1">
-                  {@html warning}
-                </div>
-                <div class="text-utility-error text-xs font-semibold">
-                  {$translate('app.errors.lightningd_not_synced')}
-                </div>
-              </div>
-            {/if}
-          </div>
-          <!-- {/if} -->
+          {/if}
         </div>
       </div>
 

--- a/src/routes/wallets/[id]/+page.svelte
+++ b/src/routes/wallets/[id]/+page.svelte
@@ -71,6 +71,15 @@
     })
 
   $: connection = $connections$.find(conn => conn.walletId === id)
+
+  $: console.log(
+    `connection = 
+  
+  
+  `,
+    connection?.info
+  )
+
   $: status = connection ? connection.connectionStatus$ : new BehaviorSubject(null)
 
   $: if ($wallet$ && !$wallet$.modifiedAt) {
@@ -242,62 +251,84 @@
             </div>
           {/if}
 
-          {#if $status === 'connected'}
-            <div>
-              <div class="flex flex-wrap gap-1" in:fade={{ duration: 250 }}>
-                <div class="flex flex-col items-center">
-                  <div class="relative w-min text-sm">
-                    <Button
-                      disabled={$wallet$ && $wallet$.syncing}
-                      on:click={sync}
-                      primary
-                      text={$translate('app.labels.sync')}
-                    >
-                      <div
-                        class:animate-spin={$wallet$ && $wallet$.syncing}
-                        class="w-4 mr-2 -ml-1"
-                        slot="iconLeft"
-                      >
-                        {@html refresh}
-                      </div>
-                    </Button>
-
-                    {#if syncProgress$}
-                      <div class="absolute top-0 left-0 p-1 w-full h-full overflow-hidden">
-                        <div class="w-full h-full rounded-full overflow-hidden relative">
-                          <div
-                            transition:slide={{ duration: 250 }}
-                            style="width: {$syncProgress$}%;"
-                            class="absolute bottom-0 left-0 h-1.5 transition-all overflow-hidden bg-purple-300"
-                          />
-                        </div>
-                      </div>
-                    {/if}
-                  </div>
-                </div>
-
-                <div class="w-min text-sm">
+          <!-- {#if $status === 'connected'} -->
+          <div>
+            <div class="flex flex-wrap gap-1" in:fade={{ duration: 250 }}>
+              <div class="flex flex-col items-center">
+                <div class="relative w-min text-sm">
                   <Button
-                    on:click={() => (showInfoModal = true)}
-                    text={$translate('app.labels.info')}
+                    disabled={$wallet$ && $wallet$.syncing}
+                    on:click={sync}
+                    primary
+                    text={$translate('app.labels.sync')}
                   >
-                    <div slot="iconLeft" class="w-5 mr-1 -ml-2">{@html qr}</div>
+                    <div
+                      class:animate-spin={$wallet$ && $wallet$.syncing}
+                      class="w-4 mr-2 -ml-1"
+                      slot="iconLeft"
+                    >
+                      {@html refresh}
+                    </div>
                   </Button>
+
+                  {#if syncProgress$}
+                    <div class="absolute top-0 left-0 p-1 w-full h-full overflow-hidden">
+                      <div class="w-full h-full rounded-full overflow-hidden relative">
+                        <div
+                          transition:slide={{ duration: 250 }}
+                          style="width: {$syncProgress$}%;"
+                          class="absolute bottom-0 left-0 h-1.5 transition-all overflow-hidden bg-purple-300"
+                        />
+                      </div>
+                    </div>
+                  {/if}
                 </div>
               </div>
 
-              <div class="w-full flex flex-col items-start mt-1.5 ml-2">
-                {#if typeof walletBalance === 'number'}
-                  <div>
-                    <BitcoinAmount sats={walletBalance} />
-                    <div class="text-xs font-semibold -mt-1">
-                      {$translate('app.labels.balance')}
-                    </div>
-                  </div>
-                {/if}
+              <div class="w-min text-sm">
+                <Button
+                  on:click={() => (showInfoModal = true)}
+                  text={$translate('app.labels.info')}
+                >
+                  <div slot="iconLeft" class="w-5 mr-1 -ml-2">{@html qr}</div>
+                </Button>
               </div>
             </div>
-          {/if}
+
+            <div class="w-full flex flex-col items-start mt-1.5 ml-2">
+              {#if typeof walletBalance === 'number'}
+                <div>
+                  <BitcoinAmount sats={walletBalance} />
+                  <div class="text-xs font-semibold">
+                    {$translate('app.labels.balance')}
+                  </div>
+                </div>
+              {/if}
+            </div>
+
+            {#if !connection?.info?.bitcoindSynced}
+              <div class="w-full flex items-end mt-1.5 ml-2">
+                <div class="w-4 text-utility-error mr-1">
+                  {@html warning}
+                </div>
+                <div class="text-utility-error text-xs font-semibold">
+                  {$translate('app.errors.bitcoind_not_synced')}
+                </div>
+              </div>
+            {/if}
+
+            {#if !connection?.info?.lightningdSynced}
+              <div class="w-full flex items-end mt-1.5 ml-2">
+                <div class="w-4 text-utility-error mr-1">
+                  {@html warning}
+                </div>
+                <div class="text-utility-error text-xs font-semibold">
+                  {$translate('app.errors.lightningd_not_synced')}
+                </div>
+              </div>
+            {/if}
+          </div>
+          <!-- {/if} -->
         </div>
       </div>
 


### PR DESCRIPTION
- Updates the `Info` type to include `bitcoindSynced` and `lightningdSynced` boolean values 
- If the warnings are found on get info - then these synced values will be set to `false`
- If either bitcoind or lightningd is not fully synced, a warning is now shown on the wallet page.

<img width="795" alt="Screenshot 2024-06-06 at 9 17 41 PM" src="https://github.com/clams-tech/Remote/assets/30157175/3b604406-ecea-4580-8833-b8aaf2fdf76a">
