### PR TITLE
Fix: Set prerender to 'auto'.

### DIFF
--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -12,7 +12,7 @@ import { createNewSession } from '$lib/session.js'
 import { decryptWithAES } from '$lib/crypto.js'
 import type { Session } from '$lib/@types/session.js'
 
-export const prerender = true
+export const prerender = 'auto'
 export const ssr = false
 
 export const load: LayoutLoad = async ({ url }) => {

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -26,35 +26,6 @@ const config = {
     },
     csrf: {
       checkOrigin: true
-    },
-    prerender: {
-      entries: [
-        '/',
-        '/wallets',
-        '/wallets/add',
-        '/wallets/[id]',
-        '/welcome',
-        '/channels',
-        '/channels/open',
-        '/channels/[id]',
-        '/input',
-        '/settings',
-        '/payments',
-        '/payments/pay/bolt11/[invoice]',
-        '/payments/pay/keysend/[pubkey]',
-        '/payments/pay/onchain/[address]',
-        '/payments/receive',
-        '/payments/[id]',
-        '/utxos',
-        '/utxos/[id]',
-        '/forwards',
-        '/forwards/[id]',
-        '/lnurl/[value]',
-        '/offers',
-        '/offers/offer/create',
-        '/offers/offer/[bolt12]',
-        '/offers/[id]'
-      ]
     }
   }
 }


### PR DESCRIPTION
I was getting the following error when trying to build the 'develop' branch:

```text
...
13.87 .svelte-kit/output/client/_app/immutable/nodes/15.de468ba7.js                        58.11 kB │ gzip: 12.84 kB
13.87 .svelte-kit/output/client/_app/immutable/chunks/ItemsList.bcce0d47.js                76.27 kB │ gzip: 23.96 kB
13.87 .svelte-kit/output/client/_app/immutable/chunks/close.2e508e22.js                   184.06 kB │ gzip: 63.34 kB
13.87 .svelte-kit/output/client/_app/immutable/chunks/index.810b345b.js                   224.85 kB │ gzip: 63.31 kB
13.87 ✓ built in 9.93s
14.55 
14.55 node:internal/event_target:1090
14.55   process.nextTick(() => { throw err; });
14.55                            ^
14.55 Error: The following routes were marked as prerenderable, but were not prerendered because they were not found while crawling your app:
14.55   - /plugins,  - /plugins/clboss
14.55 
14.55 See https://kit.svelte.dev/docs/page-options#prerender-troubleshooting for info on how to solve this
14.55     at prerender (file:///app/node_modules/@sveltejs/kit/src/core/postbuild/prerender.js:475:9)
14.55     at async MessagePort.<anonymous> (file:///app/node_modules/@sveltejs/kit/src/utils/fork.js:22:16)
14.55 
14.55 Node.js v22.6.0
14.62 error Command failed with exit code 1.
14.62 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Changing the line in the commit results in the static build process completing [as per their recommendation](https://kit.svelte.dev/docs/page-options#prerender-troubleshooting). I don't see any negative side effects of this change, but ya'll will know better.

