### PR TITLE
Fix - Only show loading spinner on plugins route if wallets exist

### DIFF
--- a/src/routes/plugins/+page.svelte
+++ b/src/routes/plugins/+page.svelte
@@ -56,8 +56,8 @@
     <SectionHeading icon={terminal} />
   </div>
   <WalletSelector wallets={$availableWallets$} bind:selectedWalletId />
-  <div class="w-full flex items-center mt-4">
-    {#if $availableWallets$.length}
+  {#if $availableWallets$.length}
+    <div class="w-full flex items-center mt-4">
       <div class="flex flex-col gap-4">
         {#if loading}
           <Spinner size="1.5em" />
@@ -99,6 +99,6 @@
           </a>
         {/if}
       </div>
-    {/if}
-  </div>
+    </div>
+  {/if}
 </Section>

--- a/src/routes/plugins/+page.svelte
+++ b/src/routes/plugins/+page.svelte
@@ -57,46 +57,48 @@
   </div>
   <WalletSelector wallets={$availableWallets$} bind:selectedWalletId />
   <div class="w-full flex items-center mt-4">
-    <div class="flex flex-col gap-4">
-      {#if loading}
-        <Spinner size="1.5em" />
-      {:else}
-        <a
-          href={clbossInstalled
-            ? `/plugins/clboss?wallet=${selectedWalletId}`
-            : 'https://github.com/ZmnSCPxj/clboss'}
-          target={clbossInstalled ? null : '_blank'}
-          rel={clbossInstalled ? null : 'noopener noreferrer'}
-          class="no-underline p-4 border rounded-lg flex flex-col justify-start mb-2 w-full"
-        >
-          <div class="flex items-center w-full justify-between gap-x-2 mb-2 flex-wrap gap-y-1">
-            <div class="font-semibold">{$translate('app.labels.clboss')}</div>
-          </div>
+    {#if $availableWallets$.length}
+      <div class="flex flex-col gap-4">
+        {#if loading}
+          <Spinner size="1.5em" />
+        {:else}
+          <a
+            href={clbossInstalled
+              ? `/plugins/clboss?wallet=${selectedWalletId}`
+              : 'https://github.com/ZmnSCPxj/clboss'}
+            target={clbossInstalled ? null : '_blank'}
+            rel={clbossInstalled ? null : 'noopener noreferrer'}
+            class="no-underline p-4 border rounded-lg flex flex-col justify-start mb-2 w-full"
+          >
+            <div class="flex items-center w-full justify-between gap-x-2 mb-2 flex-wrap gap-y-1">
+              <div class="font-semibold">{$translate('app.labels.clboss')}</div>
+            </div>
 
-          <div class="text-sm">
-            <div class="flex items-center">
-              <div
-                class:border-utility-error={!clbossInstalled}
-                class:border-utility-success={clbossInstalled}
-                class="w-4 mr-1 border rounded-full"
-              >
-                {@html clbossInstalled ? check : close}
+            <div class="text-sm">
+              <div class="flex items-center">
+                <div
+                  class:border-utility-error={!clbossInstalled}
+                  class:border-utility-success={clbossInstalled}
+                  class="w-4 mr-1 border rounded-full"
+                >
+                  {@html clbossInstalled ? check : close}
+                </div>
+                {$translate('app.labels.installed')}
               </div>
-              {$translate('app.labels.installed')}
-            </div>
-            <div class="flex items-center">
-              <div
-                class:border-utility-error={!clbossActive}
-                class:border-utility-success={clbossActive}
-                class="w-4 mr-1 border rounded-full"
-              >
-                {@html clbossActive ? check : close}
+              <div class="flex items-center">
+                <div
+                  class:border-utility-error={!clbossActive}
+                  class:border-utility-success={clbossActive}
+                  class="w-4 mr-1 border rounded-full"
+                >
+                  {@html clbossActive ? check : close}
+                </div>
+                {$translate('app.labels.active')}
               </div>
-              {$translate('app.labels.active')}
             </div>
-          </div>
-        </a>
-      {/if}
-    </div>
+          </a>
+        {/if}
+      </div>
+    {/if}
   </div>
 </Section>


### PR DESCRIPTION
Fixes issue where we have a constant spinner on the /plugins page when the user has yet to connect a wallet. We only want to see the spinner if they have already made a connection, and the app is checking to see which plugins they have installed. 