### PR TITLE
2.3.0-0.0.1: [ENH]: Make description required when creating offer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote",
-  "version": "2.3.0",
+  "version": "2.3.0-0.0.1",
   "scripts": {
     "dev": "vite dev",
     "dev-https": "vite dev --mode https",

--- a/src/routes/offers/offer/create/+page.svelte
+++ b/src/routes/offers/offer/create/+page.svelte
@@ -126,11 +126,11 @@
 
       <TextInput
         type="text"
-        label={$translate('app.labels.label')}
-        name="label"
-        bind:value={label}
-        placeholder={$translate('app.labels.offer_label_placeholder')}
-        hint={$translate('app.labels.optional')}
+        label={$translate('app.labels.description')}
+        name="description"
+        bind:value={description}
+        hint={$translate('app.labels.required')}
+        placeholder={$translate('app.labels.offer_description_placeholder')}
       />
 
       <div class="text-sm">
@@ -140,11 +140,11 @@
 
             <TextInput
               type="text"
-              label={$translate('app.labels.description')}
-              name="description"
-              bind:value={description}
+              label={$translate('app.labels.label')}
+              name="label"
+              bind:value={label}
+              placeholder={$translate('app.labels.offer_label_placeholder')}
               hint={$translate('app.labels.optional')}
-              placeholder={$translate('app.labels.offer_description_placeholder')}
             />
 
             <TextInput
@@ -166,7 +166,7 @@
       <div class="w-min">
         <Button
           requesting={creatingOffer}
-          disabled={type === 'withdraw' && !amount}
+          disabled={(type === 'withdraw' && !amount) || !description}
           on:click={createOffer}
           primary
           text={$translate('app.labels.create')}


### PR DESCRIPTION
**Background:**

Currently, when creating an offer, the user is prompted for an optional `label`. However, if a label is provided and the user clicks "create", an error occurs stating that the default offer already exists. This happens because the `description` field, nested under the dropdown, hasn’t been filled out.

**Changes:**

- Moved the `description` field to a more prominent position.
- Updated the `description` field hint to indicate that it is required.
- Disabled the "create" button until a description is provided.
- Relocated the `label` field inside the dropdown, a less prominent position.
