### PR TITLE
fix: build issue

### DIFF
--- a/src/routes/channels/open/+page.ts
+++ b/src/routes/channels/open/+page.ts
@@ -1,6 +1,8 @@
 import type { PageLoad } from './$types'
 
 export const load: PageLoad = async ({ url }) => {
-  const address = url.searchParams.get('address')
-  return { address }
+  if (typeof window !== 'undefined') {
+    const address = url.searchParams.get('address')
+    return { address }
+  }
 }

--- a/src/routes/input/+page.ts
+++ b/src/routes/input/+page.ts
@@ -1,9 +1,11 @@
 import type { PageLoad } from './$types'
 
 export const load: PageLoad = async ({ url }) => {
-  const value = url.searchParams.get('value')
+  if (typeof window !== 'undefined') {
+    const value = url.searchParams.get('value')
 
-  return {
-    value
+    return {
+      value
+    }
   }
 }

--- a/src/routes/plugins/clboss/+page.ts
+++ b/src/routes/plugins/clboss/+page.ts
@@ -1,8 +1,10 @@
 import type { PageLoad } from './$types'
 
 export const load: PageLoad = async ({ url }) => {
-  const { searchParams } = url
-  const wallet = searchParams.get('wallet')
+  if (typeof window !== 'undefined') {
+    const { searchParams } = url
+    const wallet = searchParams.get('wallet')
 
-  return { wallet }
+    return { wallet }
+  }
 }

--- a/src/routes/plugins/prism/+page.ts
+++ b/src/routes/plugins/prism/+page.ts
@@ -1,8 +1,10 @@
 import type { PageLoad } from './$types'
 
 export const load: PageLoad = async ({ url }) => {
-  const { searchParams } = url
-  const wallet = searchParams.get('wallet')
+  if (typeof window !== 'undefined') {
+    const { searchParams } = url
+    const wallet = searchParams.get('wallet')
 
-  return { wallet }
+    return { wallet }
+  }
 }

--- a/src/routes/plugins/prism/create/+page.ts
+++ b/src/routes/plugins/prism/create/+page.ts
@@ -1,8 +1,10 @@
 import type { PageLoad } from './$types'
 
 export const load: PageLoad = async ({ url }) => {
-  const { searchParams } = url
-  const wallet = searchParams.get('wallet')
+  if (typeof window !== 'undefined') {
+    const { searchParams } = url
+    const wallet = searchParams.get('wallet')
 
-  return { wallet }
+    return { wallet }
+  }
 }


### PR DESCRIPTION
Build failing with this error on multiple routes: 

```
Error: Cannot access url.searchParams on a page with prerendering enabled
    at URL.get (file:///Users/johngribbin/Repos/clams-tech/Remote/.svelte-kit/output/server/index.js:436:15)
    at load (file:///Users/johngribbin/Repos/clams-tech/Remote/.svelte-kit/output/server/entries/pages/plugins/prism/create/_page.ts.js:2:11)
    at load_data (file:///Users/johngribbin/Repos/clams-tech/Remote/.svelte-kit/output/server/index.js:2368:44)
    at async file:///Users/johngribbin/Repos/clams-tech/Remote/.svelte-kit/output/server/index.js:3732:18
ReferenceError: Worker is not defined
    at file:///Users/johngribbin/Repos/clams-tech/Remote/.svelte-kit/output/server/chunks/helpers.js:272:22
    at ModuleJob.run (node:internal/modules/esm/module_job:194:25)

node:internal/event_target:1033
  process.nextTick(() => { throw err; });
                           ^
Error: 500 /plugins/prism/create
To suppress or handle this error, implement `handleHttpError` in https://kit.svelte.dev/docs/configuration#prerender
    at file:///Users/johngribbin/Repos/clams-tech/Remote/node_modules/@sveltejs/kit/src/core/config/options.js:212:13
    at file:///Users/johngribbin/Repos/clams-tech/Remote/node_modules/@sveltejs/kit/src/core/postbuild/prerender.js:64:25
    at save (file:///Users/johngribbin/Repos/clams-tech/Remote/node_modules/@sveltejs/kit/src/core/postbuild/prerender.js:403:4)
    at visit (file:///Users/johngribbin/Repos/clams-tech/Remote/node_modules/@sveltejs/kit/src/core/postbuild/prerender.js:236:3)
Emitted 'error' event on Worker instance at:
    at [kOnErrorMessage] (node:internal/worker:300:10)
    at [kOnMessage] (node:internal/worker:311:37)
    at MessagePort.<anonymous> (node:internal/worker:212:57)
    at [nodejs.internal.kHybridDispatch] (node:internal/event_target:757:20)
    at exports.emitMessage (node:internal/per_context/messageport:23:28)

Node.js v18.18.0
```